### PR TITLE
Add requests module installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,5 +12,6 @@ setup(
     install_requires=[
         'opencv-python>=3.4.2',
         'Pillow>=6.1.0',
+        'requests>=2.22.0',
     ],
 )


### PR DESCRIPTION
It adds the request library installation in the setup.py to avoid the `ModuleNotFoundError: No module named 'requests'`.

Code to reproduce error (in Anaconda):
```
conda create -n test python==3.8
conda activate test
pip install imread-from-url
python
from imread_from_url import imread_from_url
```

Note: Creating a environment like `conda create -n test` does not generate the error since requests gets installed directly.
